### PR TITLE
PHP 8.2+ deprecation fixes - Creation of dynamic property

### DIFF
--- a/src/Scheduler/JobRecurringSchedule.php
+++ b/src/Scheduler/JobRecurringSchedule.php
@@ -18,6 +18,9 @@ use TomAtom\JobQueueBundle\Message\JobRecurringMessage;
 #[AsSchedule(JobRecurring::SCHEDULER_NAME)]
 final class JobRecurringSchedule implements ScheduleProviderInterface
 {
+
+    private ?Schedule $schedule = null;
+
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,
         private readonly LockFactory              $lockFactory,


### PR DESCRIPTION
Fixing deprecation warning -- 

`Deprecated: Creation of dynamic property TomAtom\JobQueueBundle\Scheduler\JobRecurringSchedule::$schedule is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: Creation of dynamic property TomAtom\\JobQueueBundle\\Scheduler\\JobRecurringSchedule::$schedule is deprecated at /var/www/html/vendor/tomatom/jobqueuebundle/src/Scheduler/JobRecurringSchedule.php:32)"} []`