### PR TITLE
Restrict purging of recurring jobs to bundle-managed schedule

### DIFF
--- a/src/EventListener/JobRecurringScheduleListener.php
+++ b/src/EventListener/JobRecurringScheduleListener.php
@@ -10,13 +10,13 @@ use Symfony\Component\Scheduler\Event\PreRunEvent;
 use Symfony\Component\Scheduler\RecurringMessage;
 use TomAtom\JobQueueBundle\Entity\JobRecurring;
 use TomAtom\JobQueueBundle\Message\JobRecurringMessage;
+use TomAtom\JobQueueBundle\Scheduler\JobRecurringSchedule;
 
 class JobRecurringScheduleListener implements EventSubscriberInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly LockFactory            $lockFactory,
-
     )
     {
     }
@@ -38,8 +38,17 @@ class JobRecurringScheduleListener implements EventSubscriberInterface
             return;
         }
 
-        // Access the running schedule
         $currentSchedule = $event->getSchedule();
+        if (!$currentSchedule instanceof JobRecurringSchedule) {
+            // Not our schedule, ignore
+            return;
+        }
+
+        $currentMessage = $event->getMessage();
+        if (!$currentMessage instanceof JobRecurringMessage || $currentMessage->getCommandName() !== JobRecurring::HEARTBEAT_MESSAGE) {
+            // Not the heartbeat message, ignore
+            return;
+        }
 
         // Clear existing recurring messages
         foreach ($currentSchedule->getSchedule()->getRecurringMessages() as $key => $recurringMessage) {


### PR DESCRIPTION
This PR addresses excessive re-scheduling in the JobRecurringScheduleListener.

Currently, there are two issues in my opinion:

1. The listener purges **all** schedules, including those from Symfony's native Scheduler bundle.
This means that if you have other tasks defined with the `#[AsCronTask(...)]` attribute, all but the first one are purged and will no longer be executed.
The first one still runs, but only because of the `$key === 0` check.

2. The schedule is recalculated whenever _any_ recurring job is executed, rather than only when the heartbeat is received.
With many recurring jobs, this leads to unnecessary load.